### PR TITLE
Revert "Merge pull request #8 from Jimdo/escape_newlines_in_events"

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -296,17 +296,15 @@ func (e Event) Encode(tags ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	text := e.escapedText()
-
 	var buffer bytes.Buffer
 	buffer.WriteString("_e{")
 	buffer.WriteString(strconv.FormatInt(int64(len(e.Title)), 10))
 	buffer.WriteRune(',')
-	buffer.WriteString(strconv.FormatInt(int64(len(text)), 10))
+	buffer.WriteString(strconv.FormatInt(int64(len(e.Text)), 10))
 	buffer.WriteString("}:")
 	buffer.WriteString(e.Title)
 	buffer.WriteRune('|')
-	buffer.WriteString(text)
+	buffer.WriteString(e.Text)
 
 	if !e.Timestamp.IsZero() {
 		buffer.WriteString("|d:")
@@ -352,8 +350,4 @@ func (e Event) Encode(tags ...string) (string, error) {
 	}
 
 	return buffer.String(), nil
-}
-
-func (e Event) escapedText() string {
-	return strings.Replace(e.text, "\n", "\\n", -1)
 }


### PR DESCRIPTION
This is causing compilation errors w/ our dvara version and such needs to be
temporarily rolled back.

This reverts commit 694a2805f0014581c9da2bfbe2acd3192517eac7, reversing
changes made to bc97e0770ad4edae1c9dc14beb40b79b2dde32f8.
